### PR TITLE
Updated LinkedIn regex to allow country subdomains

### DIFF
--- a/internal/isx/is.go
+++ b/internal/isx/is.go
@@ -22,7 +22,7 @@ var (
 		"facebook":  `(?:(www\.)|(m\.))?facebook.com`,
 		"github":    "github.com",
 		"instagram": `(?:(www\.)|(m\.))?instagram.com`,
-		"linkedin":  `(?:(www\.)|(m\.))?linkedin.com`,
+		"linkedin":  `(?:(www\.)|(m\.)|([a-z]{2}\.))?linkedin.com`,
 		"pinterest": `(?:(www\.))?pinterest.com`,
 		"snapchat":  `(?:(www\.))?snapchat.com`,
 		"tiktok":    `(?:(www\.)|(m\.))?tiktok.com`,

--- a/internal/isx/is_test.go
+++ b/internal/isx/is_test.go
@@ -141,6 +141,7 @@ func Test_ValidateProfileLink(t *testing.T) {
 		{"Twitter", "twitter.com/joe", false},
 		{"Instagram", "https://instagram.com/ahmed", false},
 		{"LinkedIn", "facebook.com/bincyber", true},
+		{"LinkedIn", "ca.linkedin.com/bincyber", false},
 		{"github", "https://github.com/bincyber", false},
 		{"twitter", "github.com/bincyber", true},
 		{"tiktok", "tiktok.com/@example", false},


### PR DESCRIPTION
### :hammer_and_wrench:  Description

This PR updates the regex used to validate LinkedIn domains to allow country subdomains.


### :link:  GitHub Issue

#5 


### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
