### PR TITLE
fixed monthly interval, added quadweekly option

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,11 +15,13 @@ jobs:
     name: lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
 
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -30,13 +32,13 @@ jobs:
     name: test
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19
 
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: go mod download
@@ -54,7 +56,8 @@ jobs:
     name: build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Build chat-roulette container image
         run: make docker/build/chat-roulette

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 cmd/bin/
+notes/
 .coverage.out
 config.json
 fly.toml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
   - durationcheck # checks for two durations multiplied together
   - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
   - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-  - execinquery # checks query string in Query function which reads your Go src files and warning it finds
   - exportloopref # checks for pointers to enclosing loop variables
   - forbidigo # forbids identifiers
   - gocritic # provides diagnostics that check for bugs, performance and style issues

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ go/install:
 	go get -v
 
 go/tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 	go install -tags 'postgres $(MIGRATIONS_SOURCE)' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.15.2
-	go install gotest.tools/gotestsum@v1.8.2
-	go install github.com/miniscruff/changie@v1.10.0
+	go install gotest.tools/gotestsum@v1.12.0
+	go install github.com/miniscruff/changie@v1.19.1
 
 go/tidy:
 	go mod tidy -compat=1.19

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,8 +27,8 @@ The following config options control the default chat-roulette settings for ever
 
 | Key | Environment Variable | Type | Required | Default Value | Description
 | -------- | -------- | -------- | :--------: | -------- | ------
-| `interval` | `CHATROULETTE_INTERVAL` | String | No | `biweekly` | The interval or frequency that matches will be made. <br /><br />Options: <ul><li>`weekly`</li><li>`biweekly`</li><li>`triweekly`</li><li>`monthly`</li></ul>
-| `weekday` | `CHATROULETTE_WEEKDAY` | String | No | `Monday` | The day of the week that matches will be made.
+| `interval` | `CHATROULETTE_INTERVAL` | String | No | `biweekly` | The interval or frequency that matches will be made. <br /><br />Options: <ul><li>`weekly`</li><li>`biweekly`</li><li>`triweekly`</li><li>`quadweekly`</li><li>`monthly`</li></ul>
+| `weekday` | `CHATROULETTE_WEEKDAY` | String | No | `Monday` | The day of the week that matches will be made. Supports short form (eg, `Tue` or `Thurs`)
 | `hour` | `CHATROULETTE_HOUR` | Integer | No | `12` | The hour (in UTC) that matches will be made.
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,10 +62,9 @@ ngrok by @inconshreveable                                                       
 
 Session Status                online
 Account                       bincyber (Plan: Free)
-Version                       2.3.40
-Region                        United States (us)
+Version                       3.14.0
 Web Interface                 http://127.0.0.1:4040
-Forwarding                    https://c486-174-114-137-56.ngrok.io -> http://localhost:8080
+Forwarding                    https://36a1-5-193-74-226.ngrok-free.app -> http://localhost:8080
 ```
 
 ### Install the Slack App
@@ -83,7 +82,7 @@ Copy the access token:
 2. Run the app-manifest-installer CLI to install the Slack app using the provided App Manifest:
 
 ```
-go run cmd/app-manifest/main.go -u https://YOUR-NGROK-SUBDOMAIN-HERE.ngrok.io -t xoxe.xoxp-1-SlackAppConfigurationAccessTokenHere
+go run cmd/app-manifest/main.go -u <NGROK URL HERE> -t <xoxe.xoxp-1-SlackAppConfigurationAccessTokenHere>
 ```
 
 3. Refresh your browser to view the new Slack app, then click on it. Scroll down to `Display Information` and click on `Add App Icon` to set the image for the bot:

--- a/internal/bot/event_app_home_test.go
+++ b/internal/bot/event_app_home_test.go
@@ -40,5 +40,5 @@ func Test_appHomeTemplate(t *testing.T) {
 	err = json.Unmarshal([]byte(content), &view)
 	r.NoError(err)
 	r.Equal(view.Type, slack.VTHomeTab)
-	r.Len(view.Blocks.BlockSet, 13)
+	r.Len(view.Blocks.BlockSet, 14)
 }

--- a/internal/bot/job_greet_member.go
+++ b/internal/bot/job_greet_member.go
@@ -44,8 +44,7 @@ type greetMemberTemplate struct {
 	Invitor   string
 	UserID    string
 	NextRound time.Time
-	Interval  string
-	Weekday   string
+	When      string
 }
 
 type privateMetadata struct {
@@ -113,8 +112,7 @@ func GreetMember(ctx context.Context, db *gorm.DB, client *slack.Client, p *Gree
 		Invitor:   channel.Inviter,
 		UserID:    p.UserID,
 		NextRound: channel.NextRound,
-		Weekday:   channel.Weekday.String(),
-		Interval:  channel.Interval.String(),
+		When:      formatSchedule(channel.Interval, channel.NextRound),
 	}
 
 	content, err := renderTemplate(greetMemberTemplateFilename, t)

--- a/internal/bot/job_greet_member_test.go
+++ b/internal/bot/job_greet_member_test.go
@@ -148,19 +148,35 @@ func Test_greetMemberTemplate(t *testing.T) {
 
 	nextRound := time.Date(2022, time.January, 3, 12, 0, 0, 0, time.UTC)
 
-	data := greetMemberTemplate{
-		ChannelID: "C0123456789",
-		Invitor:   "U9876543210",
-		UserID:    "U0123456789",
-		NextRound: nextRound,
-		Interval:  "biweekly",
-		Weekday:   "Monday",
-	}
+	t.Run("biweekly", func(t *testing.T) {
+		data := greetMemberTemplate{
+			ChannelID: "C0123456789",
+			Invitor:   "U9876543210",
+			UserID:    "U0123456789",
+			NextRound: nextRound,
+			When:      formatSchedule(models.Biweekly, nextRound),
+		}
 
-	content, err := renderTemplate("greet_member.json.tmpl", data)
-	assert.Nil(t, err)
+		content, err := renderTemplate("greet_member.json.tmpl", data)
+		assert.Nil(t, err)
 
-	g.Assert(t, "greet_member.json", []byte(content))
+		g.Assert(t, "greet_member.json", []byte(content))
+	})
+
+	t.Run("monthly", func(t *testing.T) {
+		data := greetMemberTemplate{
+			ChannelID: "C0123456789",
+			Invitor:   "U9876543210",
+			UserID:    "U0123456789",
+			NextRound: nextRound,
+			When:      formatSchedule(models.Monthly, nextRound),
+		}
+
+		content, err := renderTemplate("greet_member.json.tmpl", data)
+		assert.Nil(t, err)
+
+		g.Assert(t, "greet_member_monthly.json", []byte(content))
+	})
 }
 
 func Test_HandleGreetMemberButton(t *testing.T) {

--- a/internal/bot/job_notify_pair.go
+++ b/internal/bot/job_notify_pair.go
@@ -108,8 +108,8 @@ func NotifyPair(ctx context.Context, db *gorm.DB, client *slack.Client, p *Notif
 
 	if result.Error != nil {
 		message := "failed to retrieve members' info"
-		logger.Error(message, "error", err)
-		return errors.Wrap(err, message)
+		logger.Error(message, "error", result.Error)
+		return errors.Wrap(result.Error, message)
 	}
 
 	participant := participants[0]

--- a/internal/bot/schedule.go
+++ b/internal/bot/schedule.go
@@ -1,9 +1,11 @@
 package bot
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/chat-roulettte/chat-roulette/internal/database/models"
+	"github.com/chat-roulettte/chat-roulette/internal/templatex"
 	"github.com/chat-roulettte/chat-roulette/internal/timex"
 )
 
@@ -14,5 +16,25 @@ func FirstChatRouletteRound(t time.Time, weekday string, hour int) time.Time {
 
 // NextChatRouletteRound returns the timestamp of the next chat roulette round.
 func NextChatRouletteRound(t time.Time, interval models.IntervalEnum) time.Time {
-	return t.AddDate(0, 0, int(interval))
+	var timestamp time.Time
+
+	switch interval {
+	case models.Monthly:
+		timestamp = timex.NextMonth(t)
+	default:
+		timestamp = t.AddDate(0, 0, int(interval))
+	}
+
+	return timestamp
+}
+
+// formatSchedule ...
+func formatSchedule(interval models.IntervalEnum, t time.Time) string {
+	when := fmt.Sprintf("*%s* on *%ss*", templatex.Capitalize(interval.String()), t.Weekday())
+
+	if interval == models.Monthly {
+		when = fmt.Sprintf("On the *%s* of every month", timex.FormatMonthlyOccurrence(t))
+	}
+
+	return when
 }

--- a/internal/bot/schedule_test.go
+++ b/internal/bot/schedule_test.go
@@ -1,0 +1,67 @@
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chat-roulettte/chat-roulette/internal/database/models"
+)
+
+func TestNextChatRouletteRound(t *testing.T) {
+	now := time.Date(2021, time.March, 1, 12, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		interval models.IntervalEnum
+		expected time.Time
+	}{
+		{models.Weekly, time.Date(2021, time.March, 8, 12, 0, 0, 0, time.UTC)},
+		{models.Biweekly, time.Date(2021, time.March, 15, 12, 0, 0, 0, time.UTC)},
+		{models.Triweekly, time.Date(2021, time.March, 22, 12, 0, 0, 0, time.UTC)},
+		{models.Quadweekly, time.Date(2021, time.March, 29, 12, 0, 0, 0, time.UTC)},
+		{models.Monthly, time.Date(2021, time.April, 5, 12, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.interval.String(), func(t *testing.T) {
+			actual := NextChatRouletteRound(now, tt.interval)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestFormatSchedule(t *testing.T) {
+	testCases := []struct {
+		name      string
+		interval  models.IntervalEnum
+		timestamp time.Time
+		expected  string
+	}{
+		{
+			name:      "Weekly on Mondays",
+			interval:  models.Weekly,
+			timestamp: time.Date(2024, 8, 5, 0, 0, 0, 0, time.UTC),
+			expected:  "*Weekly* on *Mondays*",
+		},
+		{
+			name:      "Biweekly on Tuesdays",
+			interval:  models.Biweekly,
+			timestamp: time.Date(2024, 8, 6, 0, 0, 0, 0, time.UTC),
+			expected:  "*Biweekly* on *Tuesdays*",
+		},
+		{
+			name:      "Monthly",
+			interval:  models.Monthly,
+			timestamp: time.Date(2024, 8, 2, 0, 0, 0, 0, time.UTC),
+			expected:  "On the *first Friday* of every month",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := formatSchedule(tt.interval, tt.timestamp)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/bot/templates/app_home.json.tmpl
+++ b/internal/bot/templates/app_home.json.tmpl
@@ -2,6 +2,11 @@
 	"type": "home",
 	"blocks": [
 		{
+			"type": "image",
+			"image_url": "{{ .AppURL }}/static/img/logo.png",
+			"alt_text": "chat-roulette logo"
+		},
+		{
 			"type": "header",
 			"text": {
 				"type": "plain_text",
@@ -63,7 +68,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "<#{{ .ChannelID }}>\n:clock1: Interval: *{{ .Interval }}*\n:calendar: Next Round: *{{ .NextRound | prettyDate }}*"
+				"text": "<#{{ .ChannelID }}>\n:clock1: Interval: *{{ .Interval.String | capitalize }}*\n:calendar: Next Round: *{{ .NextRound | prettyDate }}*"
 			}
 		},
 {{ end }}{{ end }}

--- a/internal/bot/testdata/app_home.json.golden
+++ b/internal/bot/testdata/app_home.json.golden
@@ -2,6 +2,11 @@
 	"type": "home",
 	"blocks": [
 		{
+			"type": "image",
+			"image_url": "https://chat-roulette-for-slack.com/static/img/logo.png",
+			"alt_text": "chat-roulette logo"
+		},
+		{
 			"type": "header",
 			"text": {
 				"type": "plain_text",
@@ -63,7 +68,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "<#G0123456789>\n:clock1: Interval: *biweekly*\n:calendar: Next Round: *Monday, January 4th, 2021*"
+				"text": "<#G0123456789>\n:clock1: Interval: *Biweekly*\n:calendar: Next Round: *Monday, January 4th, 2021*"
 			}
 		},
 

--- a/internal/bot/testdata/greet_member.json.golden
+++ b/internal/bot/testdata/greet_member.json.golden
@@ -19,7 +19,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Chat Roulette has been enabled on this channel. *Biweekly* on *Mondays*, you will be introduced to another member in the <#C0123456789> channel. You will have until the start of the next round to meet over a video call using Slack, Zoom, Google Meet, etc.",
+                "text": "Chat Roulette has been enabled on this channel. *Biweekly* on *Mondays*, you will be introduced to another member in the <#C0123456789> channel. You will have until the start of the next round to meet over a video call using Zoom, Google Meet, Teams, etc.",
                 "verbatim": false
             }
         },

--- a/internal/bot/testdata/greet_member_monthly.json.golden
+++ b/internal/bot/testdata/greet_member_monthly.json.golden
@@ -5,21 +5,21 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":wave: Hello <@{{ .UserID }}>"
+                "text": ":wave: Hello <@U0123456789>"
             }
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Welcome to the <#{{ .ChannelID }}> channel!"
+                "text": "Welcome to the <#C0123456789> channel!"
             }
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Chat Roulette has been enabled on this channel. {{ .When }}, you will be introduced to another member in the <#{{ .ChannelID }}> channel. You will have until the start of the next round to meet over a video call using Zoom, Google Meet, Teams, etc.",
+                "text": "Chat Roulette has been enabled on this channel. On the *first Monday* of every month, you will be introduced to another member in the <#C0123456789> channel. You will have until the start of the next round to meet over a video call using Zoom, Google Meet, Teams, etc.",
                 "verbatim": false
             }
         },
@@ -27,14 +27,14 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "The next chat roulette round begins on *{{ .NextRound | prettyDate }}*!"
+                "text": "The next chat roulette round begins on *Monday, January 3rd, 2022*!"
             }
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Chat Roulette has been enabled on this channel by <@{{ .Invitor }}>, so if you have any questions, please reach out to them."
+                "text": "Chat Roulette has been enabled on this channel by <@U9876543210>, so if you have any questions, please reach out to them."
             }
         },
         {
@@ -53,7 +53,7 @@
                     "text": "Opt In",
                     "emoji": true
                 },
-                "value": "{{ .ChannelID }}",
+                "value": "C0123456789",
                 "action_id": "GREET_MEMBER|confirm"
             }
         }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,20 +178,26 @@ type SlackBotConfig struct {
 // ChatRouletteConfig stores the configuration for chat roulette
 type ChatRouletteConfig struct {
 	// Interval is the interval or frequency that matches will be made.
-	// Valid values are "weekly", "biweekly", "triweekly", or "monthly".
+	// Valid values are "weekly", "biweekly", "triweekly", "quadweekly", or "monthly".
 	//
 	// Optional
+	//
+	// Default: biweekly
 	Interval string `mapstructure:"interval"`
 
 	// Weekday is the day of the week that matches will be made.
 	// eg, Monday
 	//
 	// Optional
+	//
+	// Default: Monday
 	Weekday string `mapstructure:"weekday"`
 
 	// Hour is the hour (in UTC) that matches will be made.
 	//
 	// Optional
+	//
+	// Default: 12
 	Hour int `mapstructure:"hour"`
 }
 
@@ -223,7 +229,7 @@ type TracingConfig struct {
 // JaegerTracing contains configuration for the Jaeger exporter
 type JaegerTracing struct {
 	// Endpoint is the URL of the Jaeger collector.
-	// This is typically "http://localhost:14268/api/traces"
+	// This is typically "http://localhost:4318/v1/traces"
 	//
 	// Required
 	Endpoint string `mapstructure:"endpoint"`

--- a/internal/database/migrations/20240814235901_monthly_interval.down.sql
+++ b/internal/database/migrations/20240814235901_monthly_interval.down.sql
@@ -1,0 +1,1 @@
+ALTER TYPE INTERVAL_TYPE RENAME VALUE 'quadweekly' TO 'quadweekly_deprecated';

--- a/internal/database/migrations/20240814235901_monthly_interval.up.sql
+++ b/internal/database/migrations/20240814235901_monthly_interval.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE INTERVAL_TYPE ADD VALUE 'quadweekly';

--- a/internal/database/models/interval.go
+++ b/internal/database/models/interval.go
@@ -24,15 +24,19 @@ const (
 	// Triweekly is every 3 weeks, 21 days
 	Triweekly IntervalEnum = 21
 
-	// Monthly is every 4 weeks, 28 days
-	Monthly IntervalEnum = 28
+	// Quadweekly is every 4 weeks, 28 days
+	Quadweekly IntervalEnum = 28
+
+	// Monthly is every month on the same week
+	Monthly IntervalEnum = 30
 )
 
 var intervals = map[string]IntervalEnum{
-	"weekly":    Weekly,
-	"biweekly":  Biweekly,
-	"triweekly": Triweekly,
-	"monthly":   Monthly,
+	"weekly":     Weekly,
+	"biweekly":   Biweekly,
+	"triweekly":  Triweekly,
+	"quadweekly": Quadweekly,
+	"monthly":    Monthly,
 }
 
 func (i IntervalEnum) String() string {
@@ -43,6 +47,8 @@ func (i IntervalEnum) String() string {
 		return "biweekly"
 	case Triweekly:
 		return "triweekly"
+	case Quadweekly:
+		return "quadweekly"
 	case Monthly:
 		return "monthly"
 	default:

--- a/internal/server/ui/templates/channel.gohtml
+++ b/internal/server/ui/templates/channel.gohtml
@@ -70,7 +70,9 @@
             </option>
             <option value="triweekly" {{ if eq $.Channel.Interval.String "triweekly" }}selected{{ end }}>Every 3 Weeks
             </option>
-            <option value="monthly" {{ if eq $.Channel.Interval.String "monthly" }}selected{{ end }}>Every 4 Weeks
+            <option value="quadweekly" {{ if eq $.Channel.Interval.String "quadweekly" }}selected{{ end }}>Every 4 Weeks
+            </option>
+            <option value="monthly" {{ if eq $.Channel.Interval.String "monthly" }}selected{{ end }}>Monthly
             </option>
           </select>
           <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">

--- a/internal/timex/timex.go
+++ b/internal/timex/timex.go
@@ -17,13 +17,21 @@ func init() {
 		// support weekday long names
 		weekdays[name] = d
 
-		// support weekday short names (eg, Mon, Tues, etc.)
+		// support weekday short names (eg, Mon, Tue, etc.)
 		weekdays[name[:3]] = d
 
 		// support lowercase weekday names
 		name = strings.ToLower(name)
 		weekdays[name] = d
 		weekdays[name[:3]] = d
+
+		// Edge cases
+		switch d {
+		case time.Tuesday:
+			weekdays["Tues"] = d
+		case time.Thursday:
+			weekdays["Thurs"] = d
+		}
 	}
 }
 
@@ -32,14 +40,15 @@ func init() {
 // and short names such as "Mon", "Tue" are supported.
 // Case is ignored.
 func ParseWeekday(s string) (time.Weekday, error) {
-	if d, ok := weekdays[s]; ok {
-		return d, nil
+	day, ok := weekdays[s]
+	if !ok {
+		return time.Sunday, fmt.Errorf("invalid weekday %q", s)
 	}
 
-	return time.Sunday, fmt.Errorf("invalid weekday %q", s)
+	return day, nil
 }
 
-// NextWeekday calculates the timestamp of the next occurring weekday given a starting timestamp.
+// NextWeekday calculates the timestamp of the next occurring weekday from the given timestamp.
 func NextWeekday(t time.Time, weekday string, hour int) time.Time {
 	// Convert weekday to numeric representation
 	d, _ := ParseWeekday(weekday)
@@ -66,4 +75,70 @@ func NextWeekday(t time.Time, weekday string, hour int) time.Time {
 	timestamp = time.Date(year, month, day, hour, 0, 0, 0, time.UTC)
 
 	return timestamp
+}
+
+// NextMonth calculates the timestamp of the next occurrence in the following month from the given timestamp.
+func NextMonth(t time.Time) time.Time {
+	// Determine the weekday and ordinal occurrence
+	weekday := t.Weekday()
+	ordinal := (t.Day()-1)/7 + 1
+
+	// Move to the next month
+	month := t.Month() + 1
+	year := t.Year()
+	if month > 12 {
+		month = 1
+		year++
+	}
+
+	// Find the first day of the next month
+	firstDayNextMonth := time.Date(year, month, 1, t.Hour(), t.Minute(), 0, 0, t.Location())
+
+	// Find the first occurrence of the specified weekday in the next month
+	firstWeekday := firstDayNextMonth
+	for firstWeekday.Weekday() != t.Weekday() {
+		firstWeekday = firstWeekday.AddDate(0, 0, 1)
+	}
+
+	// Calculate the maximum number of occurrences of the specified weekday in the next month
+	maxOccurrences := 0
+	for d := firstDayNextMonth; d.Month() == month; d = d.AddDate(0, 0, 1) {
+		if d.Weekday() == weekday {
+			maxOccurrences++
+		}
+	}
+
+	// Handle edge case: current month has 4 weeks, but next month has 5 weeks
+	if ordinal == 4 && maxOccurrences == 5 {
+		ordinal = 5
+	}
+
+	// Calculate the date in the next month based on the ordinal
+	timestamp := firstWeekday.AddDate(0, 0, (ordinal-1)*7)
+
+	return timestamp
+}
+
+// FormatMonthlyOccurrence extracts the day and week number from a timestamp
+// and formats it into a human-readable string for when in the month that it occurs.
+//
+// eg, "first Monday" or "last Saturday"
+func FormatMonthlyOccurrence(t time.Time) string {
+	week := (t.Day()-1)/7 + 1
+
+	var occurrence string
+	switch week {
+	case 1:
+		occurrence = "first"
+	case 2:
+		occurrence = "second"
+	case 3:
+		occurrence = "third"
+	default:
+		occurrence = "last"
+	}
+
+	formattedString := fmt.Sprintf("%s %s", occurrence, t.Weekday())
+
+	return formattedString
 }

--- a/internal/timex/timex_test.go
+++ b/internal/timex/timex_test.go
@@ -7,6 +7,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseWeekday(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Weekday
+		isErr    bool
+	}{
+		{"Mon", time.Monday, false},
+		{"Tue", time.Tuesday, false},
+		{"Tues", time.Tuesday, false},
+		{"Thu", time.Thursday, false},
+		{"Thurs", time.Thursday, false},
+		{"Wed", time.Wednesday, false},
+		{"InvalidDay", time.Sunday, true},
+		{"F", time.Friday, true},
+		{"S", time.Saturday, true},
+		{"Satu", time.Saturday, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			actual, err := ParseWeekday(tt.input)
+			if tt.isErr {
+				// assert.Equal(t, tt.err, err, "expected error %v, got %v", tt.err, err)
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
 func Test_NextWeekday(t *testing.T) {
 	// Testing against Wednesday, Jan 13th, 2021 12:00 UTC
 	now := time.Date(2021, time.January, 13, 12, 0, 0, 0, time.UTC)
@@ -63,4 +95,83 @@ func Test_NextWeekday(t *testing.T) {
 
 		assert.Equal(t, expected, actual)
 	})
+}
+
+func TestNextMonth(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    time.Time
+		expected time.Time
+	}{
+		{
+			name:     "first Monday",
+			input:    time.Date(2024, time.June, 4, 11, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.July, 2, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "second Tuesday",
+			input:    time.Date(2024, time.June, 11, 10, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.July, 9, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "third Friday",
+			input:    time.Date(2023, time.September, 16, 8, 0, 0, 0, time.UTC),
+			expected: time.Date(2023, time.October, 21, 8, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "last Saturday",
+			input:    time.Date(2022, time.May, 28, 10, 0, 0, 0, time.UTC),
+			expected: time.Date(2022, time.June, 25, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "end of year rollover",
+			input:    time.Date(2023, time.December, 28, 15, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.January, 25, 15, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "current month has 5 weeks",
+			input:    time.Date(2022, time.May, 2, 3, 0, 0, 0, time.UTC),
+			expected: time.Date(2022, time.June, 6, 3, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "new month has 5 weeks",
+			input:    time.Date(2022, time.March, 26, 12, 0, 0, 0, time.UTC),
+			expected: time.Date(2022, time.April, 30, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "both months have 5 weeks",
+			input:    time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.February, 5, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "leap year",
+			input:    time.Date(2024, time.January, 25, 7, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.February, 29, 7, 0, 0, 0, time.UTC), // Example date
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NextMonth(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestFormatMonthlyInterval(t *testing.T) {
+	testCases := []struct {
+		input    time.Time
+		expected string
+	}{
+		{time.Date(2024, time.August, 1, 12, 0, 0, 0, time.UTC), "first Thursday"},
+		{time.Date(2024, time.August, 12, 12, 0, 0, 0, time.UTC), "second Monday"},
+		{time.Date(2024, time.August, 22, 12, 0, 0, 0, time.UTC), "last Thursday"},
+		{time.Date(2024, time.August, 21, 12, 0, 0, 0, time.UTC), "third Wednesday"},
+		{time.Date(2024, time.August, 30, 12, 0, 0, 0, time.UTC), "last Friday"},
+	}
+
+	for _, tt := range testCases {
+		actual := FormatMonthlyOccurrence(tt.input)
+		assert.Equal(t, tt.expected, actual)
+	}
 }


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Fixed a bug in `monthly` interval: it was reoccurring every 4 weeks instead of on the same week every month.

Added a new interval option to replace the old behavior of monthly: `quadweekly` which occurs every 4 weeks


### :+1:  Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] No linting issues?
