### PR TITLE
Display Physical connection mode in the UI as "In Person"

### DIFF
--- a/internal/bot/templates/app_home.json.tmpl
+++ b/internal/bot/templates/app_home.json.tmpl
@@ -64,6 +64,10 @@
 			]
 		},
 {{ range .Channels }}
+	{{- $connectionMode := .ConnectionMode.String | capitalize }}
+	{{- if eq $connectionMode "Physical" }}
+		{{ $connectionMode = "In Person" }}
+	{{- end }}
 		{
 			"type": "section",
 			"text": {
@@ -81,7 +85,7 @@
 				},
 				{
 					"type": "mrkdwn",
-					"text": ":busts_in_silhouette: Connection Mode: *{{ .ConnectionMode.String | capitalize  }}*"
+					"text": ":busts_in_silhouette: Connection Mode: *{{ $connectionMode }}*"
 				},
 				{
 					"type": "mrkdwn",

--- a/internal/server/ui/templates/channel.gohtml
+++ b/internal/server/ui/templates/channel.gohtml
@@ -99,7 +99,7 @@
             class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
             <option value="virtual" {{ if eq $.Channel.ConnectionMode.String "virtual" }}selected{{ end }}>Virtual
             </option>
-            <option value="physical" {{ if eq $.Channel.ConnectionMode.String "physical" }}selected{{ end }}>Physical
+            <option value="physical" {{ if eq $.Channel.ConnectionMode.String "physical" }}selected{{ end }}>In Person
             </option>
             <option value="hybrid" {{ if eq $.Channel.ConnectionMode.String "hybrid" }}selected{{ end }}>Hybrid
             </option>

--- a/internal/server/ui/templates/profile.gohtml
+++ b/internal/server/ui/templates/profile.gohtml
@@ -5,9 +5,14 @@
     <p class="font-medium text-xl">Chat Roulette Channels</p>
   </div>
 
-  {{ if .Channels }}
+{{ if .Channels }}
   <div class="pt-2 flex flex-wrap">
-    {{ range .Channels }}
+    {{- range .Channels }}
+      {{- $connectionMode := .ConnectionMode | capitalize }}
+
+      {{- if eq $connectionMode "Physical" }}
+          {{- $connectionMode = "In Person" }}
+      {{- end }}
     <div class="mx-1 my-1 max-w-sm rounded overflow-hidden border-solid border-2 border-inherit">
       <div class="px-6 py-4">
         <a href="/history/{{ .ChannelID }}">
@@ -18,8 +23,7 @@
           .Participants }}
         </p>
         <p class="text-gray-700 text-base" id="{{ .ChannelID }}-connection-mode">
-          <span class="font-bold">Connection Mode: </span>{{
-          .ConnectionMode }}
+          <span class="font-bold">Connection Mode: </span>{{ $connectionMode }}
         </p>
         <p class="text-gray-700 text-base">
           <span class="font-bold">Interval: </span>


### PR DESCRIPTION
### :hammer_and_wrench:  Description

`Physical` connection mode will show in the App Home and web UI as `In Person` to make it more clear to users what this connection mode means



### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
