### PR TITLE
Fixed trace sampling for Jaeger exporter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,8 @@ The following config options control the default chat-roulette settings for ever
 | `endpoint` | `TRACING_JAEGER_ENDPOINT` | String | No |  | The URL of the Jaeger OTLP HTTP collector. This must be set if the tracing exporter is set to `jaeger`.
 | `team` | `TRACING_HONEYCOMB_TEAM` | String | No |  | The [honeycomb.io](https://www.honeycomb.io/) API key. This must be set if the tracing exporter is set to `honeycomb`.
 | `dataset` | `TRACING_HONEYCOMB_DATASET` | String | No |  | The dataset to send traces to. This must be set if the tracing exporter is set to `honeycomb`.
+| - | `OTEL_TRACES_SAMPLER` | String | No | `always_on` | Configure the sampling strategy to be used.<br /><br />Options: <ul><li>`always_on`</li><li>`traceidratio`</li><li>`parentbased_traceidratio`</li></ul><br />Refer to: [General SDK Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler)
+| - | `OTEL_TRACES_SAMPLER_ARG` | String | No |  | Configure additional arguments for the sampler<br />Refer to: [General SDK Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler_arg)
 
 ###### JSON
 ```json

--- a/internal/o11y/tracing.go
+++ b/internal/o11y/tracing.go
@@ -63,7 +63,6 @@ func NewTracerProvider(cfg *config.TracingConfig) (*sdktrace.TracerProvider, err
 		}
 
 		tp = sdktrace.NewTracerProvider(
-			sdktrace.WithSampler(sdktrace.AlwaysSample()),
 			sdktrace.WithBatcher(exp),
 			sdktrace.WithResource(res),
 		)


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Trace sampling can now be configured for Jaeger exporter using `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables



### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
