### PR TITLE
Remove unused ChatRouletteConfig

### DIFF
--- a/cmd/chat-roulette/main.go
+++ b/cmd/chat-roulette/main.go
@@ -158,8 +158,7 @@ func run() error {
 
 	// Sync channels during startup
 	if err := bot.QueueSyncChannelsJob(ctx, s.GetDB(), &bot.SyncChannelsParams{
-		BotUserID:          s.GetSlackBotUserID(),
-		ChatRouletteConfig: s.GetChatRouletteConfig(),
+		BotUserID: s.GetSlackBotUserID(),
 	}); err != nil {
 		logger.Error("failed to queue SYNC_CHANNELS job on startup", "error", err)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-_Chat Roulette for Slack_ supports configuration via JSON config file and/or environment variables. Environment variables take precedence over whatever is in the config file.
+_Chat Roulette for Slack_ supports configuration via a JSON config file and/or environment variables. Environment variables take precedence over whatever is in the config file.
 
 See [config.example.json](./examples/config.example.json) for an example of how to modify the configuration of the app using a JSON config file.
 
@@ -17,29 +17,6 @@ See [config.example.json](./examples/config.example.json) for an example of how 
 {
     "bot": {
         "auth_token": "xoxb-9876543210123-4567778889990-f0A2GclR80dgPZLTUEq5asHm"
-    }
-}
-```
-
-#### Chat Roulette Config
-
-The following config options control the default chat-roulette settings for every new Slack channel. Customizing settings per channel can be done via the UI.
-
-| Key | Environment Variable | Type | Required | Default Value | Description
-| -------- | -------- | -------- | :--------: | -------- | ------
-| `interval` | `CHATROULETTE_INTERVAL` | String | No | `biweekly` | The interval or frequency that matches will be made. <br /><br />Options: <ul><li>`weekly`</li><li>`biweekly`</li><li>`triweekly`</li><li>`quadweekly`</li><li>`monthly`</li></ul>
-| `weekday` | `CHATROULETTE_WEEKDAY` | String | No | `Monday` | The day of the week that matches will be made. Supports short form (eg, `Tue` or `Thurs`)
-| `hour` | `CHATROULETTE_HOUR` | Integer | No | `12` | The hour (in UTC) that matches will be made.
-| `connection_mode` | `CHATROULETTE_CONNECTION_MODE` | String | No | `virtual` | The type of connections that the chat-roulette bot will encourage. <br /><br />Options: <ul><li>`virtual`</li><li>`physical`</li><li>`hybrid`</li></ul>
-
-###### JSON
-```json
-{
-    "chatroulette": {
-        "interval": "monthly",
-        "weekday": "Friday",
-        "hour": 10,
-        "connection_mode": "hybrid"
     }
 }
 ```

--- a/docs/examples/config.example.json
+++ b/docs/examples/config.example.json
@@ -2,12 +2,6 @@
     "bot": {
         "auth_token": "xoxb-slackbot-oauthtoken-here"
     },
-    "chatroulette": {
-        "interval": "biweekly",
-        "weekday": "Monday",
-        "hour": 12,
-        "connection_mode": "virtual"
-    },
     "server": {
         "client_id": "oauth-client-id-here",
         "client_secret": "oauth-client-secret-here",

--- a/internal/bot/job_sync_channels.go
+++ b/internal/bot/job_sync_channels.go
@@ -10,15 +10,13 @@ import (
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
-	"github.com/chat-roulettte/chat-roulette/internal/config"
 	"github.com/chat-roulettte/chat-roulette/internal/database/models"
 	"github.com/chat-roulettte/chat-roulette/internal/o11y/attributes"
 )
 
 // SyncChannelsParams are the parameters for SYNC_CHANNEL job.
 type SyncChannelsParams struct {
-	BotUserID          string                    `json:"bot_user_id"`
-	ChatRouletteConfig config.ChatRouletteConfig `json:"config"`
+	BotUserID string `json:"bot_user_id"`
 }
 
 // SyncChannels ensures that there is no discrepancy between the Slack channels in

--- a/internal/bot/job_sync_channels_test.go
+++ b/internal/bot/job_sync_channels_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
-	"github.com/chat-roulettte/chat-roulette/internal/config"
 	"github.com/chat-roulettte/chat-roulette/internal/database"
 	"github.com/chat-roulettte/chat-roulette/internal/database/models"
 	"github.com/chat-roulettte/chat-roulette/internal/o11y"
@@ -112,11 +111,6 @@ func (s *SyncChannelsSuite) Test_SyncChannels() {
 
 	p := &SyncChannelsParams{
 		BotUserID: "U1111111111",
-		ChatRouletteConfig: config.ChatRouletteConfig{
-			Interval: "weekly",
-			Weekday:  "Monday",
-			Hour:     12,
-		},
 	}
 
 	err = SyncChannels(s.ctx, db, client, p)
@@ -138,11 +132,6 @@ func (s *SyncChannelsSuite) Test_SyncChannelsJob() {
 
 	p := &SyncChannelsParams{
 		BotUserID: "U1111111111",
-		ChatRouletteConfig: config.ChatRouletteConfig{
-			Interval: "weekly",
-			Weekday:  "Monday",
-			Hour:     12,
-		},
 	}
 
 	database.MockQueueJob(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,13 +19,12 @@ import (
 
 // Config stores the configuration for the application
 type Config struct {
-	Bot          SlackBotConfig
-	ChatRoulette ChatRouletteConfig
-	Database     DatabaseConfig
-	Server       ServerConfig
-	Worker       WorkerConfig
-	Tracing      TracingConfig
-	Dev          bool
+	Bot      SlackBotConfig
+	Database DatabaseConfig
+	Server   ServerConfig
+	Worker   WorkerConfig
+	Tracing  TracingConfig
+	Dev      bool
 }
 
 // DatabaseConfig stores the configuration for using the database
@@ -175,40 +174,6 @@ type SlackBotConfig struct {
 	AuthToken string `mapstructure:"auth_token"`
 }
 
-// ChatRouletteConfig stores the configuration for chat roulette
-type ChatRouletteConfig struct {
-	// Interval is the interval or frequency that matches will be made.
-	// Valid values are "weekly", "biweekly", "triweekly", "quadweekly", or "monthly".
-	//
-	// Optional
-	//
-	// Default: biweekly
-	Interval string `mapstructure:"interval"`
-
-	// Weekday is the day of the week that matches will be made.
-	// eg, Monday
-	//
-	// Optional
-	//
-	// Default: Monday
-	Weekday string `mapstructure:"weekday"`
-
-	// Hour is the hour (in UTC) that matches will be made.
-	//
-	// Optional
-	//
-	// Default: 12
-	Hour int `mapstructure:"hour"`
-
-	// ConnectionMode is the mode (physical) of connections that will be made.
-	// Valid values are "virtual", "physical", or "hybrid".
-	//
-	// Optional
-	//
-	// Default: virtual
-	ConnectionMode string `mapstructure:"connection_mode"`
-}
-
 // TracingConfig stores the configuration for OpenTelemetry tracing.
 // Only one exporter can be configured at a time.
 type TracingConfig struct {
@@ -256,17 +221,11 @@ type HoneycombTracing struct {
 	Dataset string `mapstructure:"dataset"`
 }
 
-func newDefaultConfig() Config {
-	return Config{
+func newDefaultConfig() *Config {
+	return &Config{
 		Server: ServerConfig{
 			Address: DefaultServerAddr,
 			Port:    DefaultServerPort,
-		},
-		ChatRoulette: ChatRouletteConfig{
-			Interval:       DefaultChatRouletteInterval,
-			Weekday:        DefaultChatRouletteWeekday,
-			Hour:           DefaultChatRouletteHour,
-			ConnectionMode: DefaultChatRouletteConnectionMode,
 		},
 		Worker: WorkerConfig{
 			Concurrency: DefaultWorkerConcurrency,
@@ -319,10 +278,7 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
-	// Normalize settings
-	config.ChatRoulette.Interval = strings.ToLower(config.ChatRoulette.Interval)
-
-	return &config, nil
+	return config, nil
 }
 
 // Validate verifies the configuration
@@ -332,16 +288,6 @@ func (c Config) Validate() error {
 		validation.Field(&c.Bot.AuthToken, validation.By(isx.SlackBotAuthToken)),
 	); err != nil {
 		return errors.Wrap(err, "failed to validate bot config")
-	}
-
-	// Validate chat-roulette config
-	if err := validation.ValidateStruct(&c.ChatRoulette,
-		validation.Field(&c.ChatRoulette.Interval, validation.By(isx.Interval)),
-		validation.Field(&c.ChatRoulette.Weekday, validation.By(isx.Weekday)),
-		validation.Field(&c.ChatRoulette.Hour, validation.Required, validation.Min(0), validation.Max(23)),
-		validation.Field(&c.ChatRoulette.ConnectionMode, validation.By(isx.ConnectionMode)),
-	); err != nil {
-		return errors.Wrap(err, "failed to validate chat-roulette config")
 	}
 
 	// Validate database config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,11 +9,11 @@ import (
 func Test_Validate(t *testing.T) {
 	type test struct {
 		name  string
-		conf  Config
+		conf  *Config
 		isErr bool
 	}
 
-	newValidConfig := func() Config {
+	newValidConfig := func() *Config {
 		conf := newDefaultConfig()
 
 		conf.Bot.AuthToken = "xoxb-9876543210123-4567778889990-f0A2GclR80dgPZLTUEq5asHm"
@@ -33,29 +33,20 @@ func Test_Validate(t *testing.T) {
 	tt := []test{
 		{"default", newDefaultConfig(), true},
 		{"valid", newValidConfig(), false},
-		{"invalid database config", func() Config {
+		{"invalid database config", func() *Config {
 			conf := newValidConfig()
 
 			conf.Database.URL = "postgres://"
 			return conf
 		}(), true},
-		{"invalid chat-roulette config", func() Config {
-			conf := newValidConfig()
-
-			conf.ChatRoulette.Hour = 24
-			conf.ChatRoulette.Interval = "every 2 weeks"
-			conf.ChatRoulette.Weekday = "foo"
-			conf.ChatRoulette.ConnectionMode = "other"
-			return conf
-		}(), true},
-		{"invalid tracing config", func() Config {
+		{"invalid tracing config", func() *Config {
 			conf := newValidConfig()
 
 			conf.Tracing.Enabled = true
 			conf.Tracing.Exporter = "x-ray"
 			return conf
 		}(), true},
-		{"invalid server config", func() Config {
+		{"invalid server config", func() *Config {
 			conf := newValidConfig()
 
 			conf.Server.RedirectURL = "https://example.com/callback"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -6,11 +6,6 @@ import (
 )
 
 const (
-	DefaultChatRouletteInterval       = "biweekly"
-	DefaultChatRouletteWeekday        = "Monday"
-	DefaultChatRouletteHour           = 12 // UTC
-	DefaultChatRouletteConnectionMode = "virtual"
-
 	DefaultServerAddr = "0.0.0.0"
 	DefaultServerPort = 8080
 

--- a/internal/server/api/v1/events.go
+++ b/internal/server/api/v1/events.go
@@ -96,8 +96,7 @@ func (s *implServer) slackEventHandler(w http.ResponseWriter, r *http.Request) {
 				// Inviter is blank if the bot is added by default to the channel
 				if ev.Inviter == "" {
 					p := &bot.SyncChannelsParams{
-						BotUserID:          ev.User,
-						ChatRouletteConfig: s.GetChatRouletteConfig(),
+						BotUserID: ev.User,
 					}
 
 					if err := bot.QueueSyncChannelsJob(r.Context(), db, p); err != nil {

--- a/internal/server/api/v1/events_test.go
+++ b/internal/server/api/v1/events_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/go-hclog"
@@ -103,17 +102,7 @@ func Test_slackEventHandler_BotJoinedChannelEvent(t *testing.T) {
 	userID := "U1111111111"
 	inviter := "U2222222222"
 
-	conf := &config.Config{
-		ChatRoulette: config.ChatRouletteConfig{
-			Interval:       models.Weekly.String(),
-			Weekday:        time.Monday.String(),
-			Hour:           12,
-			ConnectionMode: models.VirtualConnectionMode.String(),
-		},
-	}
-
 	opts := &server.ServerOptions{
-		Config:         conf,
 		DB:             db,
 		DevMode:        true,
 		SlackBotUserID: userID,
@@ -179,17 +168,7 @@ func Test_slackEventHandler_BotJoinedChannelEvent_failure(t *testing.T) {
 	userID := "U1111111111"
 	inviter := "U2222222222"
 
-	conf := &config.Config{
-		ChatRoulette: config.ChatRouletteConfig{
-			Interval:       "weekly",
-			Weekday:        "Monday",
-			Hour:           12,
-			ConnectionMode: "virtual",
-		},
-	}
-
 	opts := &server.ServerOptions{
-		Config:         conf,
 		DB:             db,
 		DevMode:        true,
 		SlackBotUserID: userID,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -196,11 +196,6 @@ func (s *Server) GetDB() *gorm.DB {
 	return s.db
 }
 
-// GetConfig retrieves the chat roulette config
-func (s *Server) GetChatRouletteConfig() config.ChatRouletteConfig {
-	return s.config.ChatRoulette
-}
-
 // GetHTTPClient retrieves the http client
 func (s *Server) GetHTTPClient() *http.Client {
 	return s.httpClient

--- a/internal/server/ui/profile.go
+++ b/internal/server/ui/profile.go
@@ -117,7 +117,7 @@ func (s *implServer) profileHandler(w http.ResponseWriter, r *http.Request) {
 		channel, err := lookupSlackChannel(r.Context(), cache, slackClient, c.ChannelID)
 		if err != nil {
 			span.RecordError(err)
-			logger.Error("failed to lookup Slack channel", "error", err, c.ChannelID)
+			logger.Error("failed to lookup Slack channel", "error", err, attributes.SlackChannelID, c.ChannelID)
 			rend.HTML(w, http.StatusInternalServerError, "500", nil)
 			return
 		}


### PR DESCRIPTION
### :hammer_and_wrench:  Description

In https://github.com/chat-roulettte/chat-roulette/pull/41, an onboarding process was added for new channels. This removed the need for chat roulette settings to be configured for the app as a whole. This PR removes the deprecated settings and simplifies the configuration


### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
