### PR TITLE
mark job as completed regardless of completion status

### DIFF
--- a/internal/bot/job_check_pair.go
+++ b/internal/bot/job_check_pair.go
@@ -176,7 +176,7 @@ func HandleCheckPairButtons(ctx context.Context, client *http.Client, db *gorm.D
 				Where("status = ?", models.JobStatusPending).
 				Where("is_completed = false").
 				Where("job_type = ?", models.JobTypeCheckPair.String()).
-				Updates(&models.Job{Status: models.JobStatusCanceled})
+				Updates(&models.Job{IsCompleted: true, Status: models.JobStatusCanceled})
 
 			if result.Error != nil {
 				return errors.Wrap(result.Error, "failed to cancel pending CHECK_PAIR job")

--- a/internal/bot/job_check_pair_test.go
+++ b/internal/bot/job_check_pair_test.go
@@ -382,9 +382,10 @@ func Test_HandleCheckPairButtons_Yes_MidRound(t *testing.T) {
 	db, mock := database.NewMockedGormDB()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE "jobs" SET "status"=(.+),"updated_at"=(.+) WHERE .* status = (.+) AND is_completed = false AND job_type = (.+)`).
+	mock.ExpectExec(`UPDATE "jobs" SET "status"=(.+),"is_completed"=(.+),"updated_at"=(.+) WHERE .* status = (.+) AND is_completed = false AND job_type = (.+)`).
 		WithArgs(
 			models.JobStatusCanceled,
+			true,
 			database.AnyTime(),
 			"match_id",
 			"99",

--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -162,7 +162,7 @@ type Job struct {
 	// Status is the completion status (success, failed, etc.) for a job
 	Status jobStatusEnum
 
-	// IsCompleted is a boolean flag for checking if the job has been completed
+	// IsCompleted is a boolean flag for checking if the job has been completed regardless of completion status
 	IsCompleted bool
 
 	// Data is the JSON data for the job


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Fixed a bug where a job's `is_completed` field was not being marked as true regardless of the completion status


### :link:  GitHub Issue

<!-- Specify the GitHub issue id (eg, #123) to auto-link the pull request to it. -->


### :+1:  Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] No linting issues?
