### PR TITLE
Skip queuing ADD_MEMBER job for the chat-roulette bot

### DIFF
--- a/internal/bot/bot_user.go
+++ b/internal/bot/bot_user.go
@@ -18,9 +18,8 @@ func GetBotUserID(ctx context.Context, client *slack.Client) (string, error) {
 	return resp.UserID, nil
 }
 
-// IsUserABot uses Slack's users.info API method
-// to check if the given user is actually a bot.
-func IsUserABot(ctx context.Context, client *slack.Client, userID string) (bool, error) {
+// isUserASlackBot uses Slack's users.info API method to check if the given user is actually a bot.
+func isUserASlackBot(ctx context.Context, client *slack.Client, userID string) (bool, error) {
 	resp, err := client.GetUserInfoContext(ctx, userID)
 	if err != nil {
 		return false, err

--- a/internal/bot/bot_user_test.go
+++ b/internal/bot/bot_user_test.go
@@ -41,7 +41,7 @@ func Test_IsUserABot(t *testing.T) {
 
 		client := slack.New("xoxb-test-token-here", slack.OptionAPIURL(slackServer.GetAPIURL()))
 
-		boolean, err := IsUserABot(context.Background(), client, "W012A3CDE")
+		boolean, err := isUserASlackBot(context.Background(), client, "W012A3CDE")
 		assert.Nil(t, err)
 		assert.False(t, boolean)
 	})
@@ -49,7 +49,7 @@ func Test_IsUserABot(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		client := slack.New("xoxb-invalid-slack-authtoken")
 
-		_, err := IsUserABot(context.Background(), client, "W012A3CDE")
+		_, err := isUserASlackBot(context.Background(), client, "W012A3CDE")
 		assert.NotNil(t, err)
 	})
 }

--- a/internal/bot/job_add_member_test.go
+++ b/internal/bot/job_add_member_test.go
@@ -94,7 +94,7 @@ func (s *AddMemberSuite) Test_AddMember() {
 	err := AddMember(s.ctx, s.db, client, p)
 	r.NoError(err)
 	r.Contains(s.buffer.String(), "added Slack user to the database")
-	r.Contains(s.buffer.String(), "queued GREET_MEMBER job for this match")
+	r.Contains(s.buffer.String(), "queued GREET_MEMBER job for this user")
 }
 
 func (s *AddMemberSuite) Test_QueueAddMemberJob() {

--- a/internal/bot/job_greet_admin.go
+++ b/internal/bot/job_greet_admin.go
@@ -228,6 +228,7 @@ func UpsertChannelSettings(ctx context.Context, db *gorm.DB, interaction *slack.
 		Weekday:        firstRound.Weekday().String(),
 		Hour:           firstRound.Hour(),
 		NextRound:      firstRound,
+		// BotUserID:      "", // TODO
 	}
 
 	if err := QueueAddChannelJob(ctx, db, p); err != nil {

--- a/internal/bot/job_sync_members_test.go
+++ b/internal/bot/job_sync_members_test.go
@@ -45,12 +45,14 @@ func (s *SyncMembersSuite) Test_SyncMembers() {
 
 	addMember := "U5555555555"    // this user will be created
 	deleteMember := "U9999999999" // this user will be deleted
+	botUser := "W012A3CDE"        // this bot user will be skipped
 
 	slackMembers := []string{
 		"U0123456789",
 		"U9876543210",
 		"U1111111111",
 		addMember,
+		botUser,
 	}
 
 	// Mock Slack API call
@@ -106,6 +108,7 @@ func (s *SyncMembersSuite) Test_SyncMembers() {
 
 	err := SyncMembers(s.ctx, s.db, client, p)
 	r.NoError(err)
+	r.Contains(s.buffer.String(), "skipping chat-roulette bot user")
 }
 
 func (s *SyncMembersSuite) Test_SyncMembersJob() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,12 +93,16 @@ func New(ctx context.Context, logger hclog.Logger, c *config.Config) (*Server, e
 	slackClient, httpClient := slackclient.New(logger, c.Bot.AuthToken)
 
 	// Retrieve the user_id of the chat-roulette Slack bot
-	logger.Debug("retrieving the user ID of the Slack bot")
-	slackBotUserID, err := bot.GetBotUserID(ctx, slackClient)
+	logger.Debug("retrieving the user ID of the chat-roulette Slack bot")
+
+	slackCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	defer cancel()
+
+	slackBotUserID, err := bot.GetBotUserID(slackCtx, slackClient)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to retrieve the user ID of the Slack bot")
+		return nil, errors.Wrap(err, "failed to retrieve the user ID of the chat-roulette Slack bot")
 	}
-	logger.Debug("retrieved the user_id of the Slack bot", "slack_bot_user_id", slackBotUserID)
+	logger.Debug("retrieved the user ID of the chat-roulette Slack bot", "slack_bot_user_id", slackBotUserID)
 	span.SetAttributes(
 		attribute.String("slack_bot_user_id", slackBotUserID),
 	)


### PR DESCRIPTION
### :hammer_and_wrench:  Description

This is a bugfix to prevent an unnecessary `ADD_MEMBER` job being queued for the chat-roulette bot



### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
