### PR TITLE
Fixed bug in MARK_INACTIVE job for users who responded YES to CHECK_PAIR button

### DIFF
--- a/internal/bot/job_mark_inactive.go
+++ b/internal/bot/job_mark_inactive.go
@@ -52,7 +52,6 @@ func MarkInactive(ctx context.Context, db *gorm.DB, client *slack.Client, p *Mar
 	defer cancel()
 
 	result := db.WithContext(dbCtx).Model(&models.Match{}).
-		Where("has_met = false").
 		Where("id = ?", p.MatchID).
 		Find(&match)
 

--- a/internal/bot/job_mark_inactive_test.go
+++ b/internal/bot/job_mark_inactive_test.go
@@ -410,7 +410,7 @@ func (s *MarkInactiveSuite) Test_QueueMarkInactiveJob() {
 	err := QueueMarkInactiveJob(s.ctx, db, p, nextRound.Add(-24*time.Hour))
 	r.NoError(err)
 	r.Contains(s.buffer.String(), "added new job to the database")
-	mock.ExpectationsWereMet()
+	r.NoError(mock.ExpectationsWereMet())
 }
 
 func Test_MarkInactive_suite(t *testing.T) {


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What code changed, and why? -->

Users who have responded "Yes" to the `CHECK_PAIR` button can still be marked as inactive if they have not exchanged any messages with the other person they have been introduced to because they have incorrectly responded to the question.


### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
