### PR TITLE
Aligned context timeout for all HTTP calls to the Slack API to accommodate tail latency

### DIFF
--- a/internal/bot/channels.go
+++ b/internal/bot/channels.go
@@ -55,7 +55,7 @@ func getChannels(ctx context.Context, client *slack.Client, botUserID string) ([
 	}
 
 	// Set deadline for Slack API call
-	ctx, cancel := context.WithTimeout(ctx, 2000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	// Skip pagination, assume bot is not a member of more than 100 channels
@@ -89,7 +89,7 @@ func getChannelMembers(ctx context.Context, client *slack.Client, channelID stri
 	var channelMembers []chatRouletteMember
 	for {
 		// Set deadline for Slack API call
-		ctx, cancel := context.WithTimeout(ctx, 2000*time.Millisecond)
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 
 		members, cursor, err := client.GetUsersInConversationContext(ctx, params)

--- a/internal/bot/job_check_pair.go
+++ b/internal/bot/job_check_pair.go
@@ -78,7 +78,7 @@ func CheckPair(ctx context.Context, db *gorm.DB, client *slack.Client, p *CheckP
 	//
 	// The interaction will be received by our /interactions endpoint
 	// and handled outside of this job.
-	slackCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	slackCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	if _, _, err = client.PostMessageContext(

--- a/internal/bot/job_greet_admin.go
+++ b/internal/bot/job_greet_admin.go
@@ -67,7 +67,7 @@ func GreetAdmin(ctx context.Context, db *gorm.DB, client *slack.Client, p *Greet
 	}
 
 	// Open a Slack DM with the user
-	childCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	response, _, _, err := client.OpenConversationContext(

--- a/internal/bot/job_greet_member.go
+++ b/internal/bot/job_greet_member.go
@@ -96,7 +96,7 @@ func GreetMember(ctx context.Context, db *gorm.DB, client *slack.Client, p *Gree
 	}
 
 	// Open a Slack DM with the user
-	childCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	response, _, _, err := client.OpenConversationContext(

--- a/internal/bot/job_kickoff_pair.go
+++ b/internal/bot/job_kickoff_pair.go
@@ -82,7 +82,7 @@ func KickoffPair(ctx context.Context, db *gorm.DB, client *slack.Client, p *Kick
 	}
 
 	// Check if the pair have already started a discussion
-	slackCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	slackCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	history, err := client.GetConversationHistoryContext(slackCtx, &slack.GetConversationHistoryParameters{

--- a/internal/bot/job_notify_member.go
+++ b/internal/bot/job_notify_member.go
@@ -72,7 +72,7 @@ func NotifyMember(ctx context.Context, db *gorm.DB, client *slack.Client, p *Not
 	}
 
 	// Open a Slack DM with the user
-	childCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	response, _, _, err := client.OpenConversationContext(

--- a/internal/bot/job_notify_pair.go
+++ b/internal/bot/job_notify_pair.go
@@ -64,7 +64,7 @@ func NotifyPair(ctx context.Context, db *gorm.DB, client *slack.Client, p *Notif
 	}
 
 	// Create a Slack Group DM with the pair of participants and update the database
-	childCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	response, _, _, err := client.OpenConversationContext(childCtx,
@@ -145,7 +145,7 @@ func NotifyPair(ctx context.Context, db *gorm.DB, client *slack.Client, p *Notif
 	}
 
 	// Send the Slack group message to the pair
-	slackCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+	slackCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	if _, _, err = client.PostMessageContext(

--- a/internal/bot/job_report_matches.go
+++ b/internal/bot/job_report_matches.go
@@ -135,7 +135,7 @@ func ReportMatches(ctx context.Context, db *gorm.DB, client *slack.Client, p *Re
 		}
 
 		// Open a Slack DM with the chat-roulette admin
-		slackCtx, cancel := context.WithTimeout(ctx, 3000*time.Millisecond)
+		slackCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 
 		response, _, _, err := client.OpenConversationContext(
@@ -152,10 +152,10 @@ func ReportMatches(ctx context.Context, db *gorm.DB, client *slack.Client, p *Re
 			multiErr = err
 		}
 
-		slackCtx, cancel = context.WithTimeout(ctx, 3000*time.Millisecond)
+		// Send a private message to the admin
+		slackCtx, cancel = context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 
-		// Send a private message to the admin
 		if _, _, err = client.PostMessageContext(
 			slackCtx,
 			response.ID,

--- a/internal/server/ui/cache.go
+++ b/internal/server/ui/cache.go
@@ -30,7 +30,7 @@ func lookupSlackWorkspace(ctx context.Context, cache *ristretto.Cache, client *s
 		return t, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 2000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	teamInfo, err := client.GetTeamInfoContext(ctx)
@@ -56,7 +56,7 @@ func lookupSlackChannel(ctx context.Context, cache *ristretto.Cache, client *sla
 		return c, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 2000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	p := &slack.GetConversationInfoInput{
@@ -87,7 +87,7 @@ func lookupSlackUser(ctx context.Context, cache *ristretto.Cache, client *slack.
 		return u, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 2000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	user, err := client.GetUserInfoContext(ctx, userID)


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Fixes occasional `context deadline exceeded` errors that occurred when calling Slack took more than 2 seconds.


### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
