### PR TITLE
Fixed bug in REPORT_STATS job when no groups met

### DIFF
--- a/internal/bot/job_report_stats_test.go
+++ b/internal/bot/job_report_stats_test.go
@@ -107,19 +107,22 @@ func Test_reportStatsTemplate(t *testing.T) {
 		percent  float64
 		contains []string
 	}{
-		{"all met", 10, 10, 100, []string{}},
+		{"all met", 10, 10, 100, []string{
+			"Congratulations to everyone for achieving *100%* :tada:",
+		}},
 		{"half met", 10, 5, 50, []string{
 			"This round had *20* participants",
-			"*5* groups met",
-			"*50%* of the *10* intros made",
+			"*5* groups met :partying_face:",
+			"*50%* of the *10* intros made :confetti_ball:",
 		}},
 		{"one group met", 4, 1, 25, []string{
 			"*1* group met",
 			"*25%* of the *4* intros made",
+			"Can you get to *100%* next round?",
 		}},
 		{"none met", 20, 0, 0, []string{
 			"This round had *40* participants",
-			"*0* groups met",
+			"*0* groups met :smiling_face_with_tear:",
 			"*0%* of the *20* intros made",
 		}},
 		{"no pairs", 0, 0, 0, []string{

--- a/internal/bot/templates/report_stats.json.tmpl
+++ b/internal/bot/templates/report_stats.json.tmpl
@@ -64,14 +64,14 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "*{{ .Met }}* {{ $groupsKeyword }} met :partying_face:"
+				"text": "*{{ .Met }}* {{ $groupsKeyword }} met {{ if eq .Met 0.0 }}:smiling_face_with_tear:{{ else }}:partying_face:{{ end }}"
 			}
 		},
 		{
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "That's *{{ .Percent | prettyPercent }}* of the *{{ .Pairs }}* intros made :confetti_ball:"
+				"text": "That's *{{ .Percent | prettyPercent }}* of the *{{ .Pairs }}* intros made {{ if gt .Percent 0.0 }}:confetti_ball:{{ end }}"
 			}
 		},
 		{{- if eq .Percent 100.0 }}


### PR DESCRIPTION
### :hammer_and_wrench:  Description

The end of round stats were showing celebratory emojis when no groups met:

<!-- What code changed, and why? -->
<img width="547" height="315" alt="Screenshot" src="https://github.com/user-attachments/assets/d57e6bc0-cf4f-4f4d-a0d4-e80cebeca216" />



### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
