### PR TITLE
Include Connection Mode preferences in the admin report

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/akamensky/argparse v1.4.0
 	github.com/bincyber/go-sqlcrypter v0.2.0
+	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/coreos/go-oidc/v3 v3.15.0
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/dmarkham/enumer v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bincyber/go-sqlcrypter v0.2.0 h1:RN37uO15GWNIrR8HMC2JYMKj7nutZrQUyA9u+Uw2IKs=
 github.com/bincyber/go-sqlcrypter v0.2.0/go.mod h1:UREzsLJG+jhsO2F7ASwhQB05Jr7JWfarsEcjToWUhRs=
+github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
+github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=

--- a/internal/bot/job_report_matches_test.go
+++ b/internal/bot/job_report_matches_test.go
@@ -50,12 +50,32 @@ func Test_reportMatchesTemplate(t *testing.T) {
 		g.Assert(t, "report_matches_admin.json", []byte(content))
 	})
 
+	t.Run("admin hybrid connection mode", func(t *testing.T) {
+		data.IsAdmin = true
+		data.Participants = 51
+		data.Men = 20
+		data.Women = 30
+		data.HasGenderPreference = 6
+		data.Unpaired = 1
+		data.Pairs = 25
+		data.IsHybridConnectionMode = true
+		data.PreferredVirtual = 10
+		data.PreferredInPerson = 30
+		data.PreferredHybrid = 11
+
+		content, err := renderTemplate(reportMatchesTemplateFilename, data)
+		assert.Nil(t, err)
+
+		g.Assert(t, "report_matches_admin_connection_mode.json", []byte(content))
+	})
+
 	t.Run("admin zero participants", func(t *testing.T) {
 		data.IsAdmin = true
 		data.Participants = 0
 		data.Men = 0
 		data.Women = 0
 		data.HasGenderPreference = 0
+		data.IsHybridConnectionMode = false
 		data.Unpaired = 0
 		data.Pairs = 0
 
@@ -186,9 +206,14 @@ func (s *ReportMatchesSuite) Test_ReportMatches() {
 	// Mock stat lookups
 	s.mock.ExpectQuery(`SELECT .* FROM "pairings" JOIN .* WHERE matches.round_id = (.+)`).
 		WithArgs(
+			models.Male,
+			models.Female,
+			models.ConnectionModeVirtual,
+			models.ConnectionModePhysical,
+			models.ConnectionModeHybrid,
 			roundID,
 		).
-		WillReturnRows(sqlmock.NewRows([]string{"men", "women", "has_gender_preference"}).AddRow([]driver.Value{5, 5, 0}...))
+		WillReturnRows(sqlmock.NewRows([]string{"men", "women", "has_gender_preference", "preferred_virtual", "preferred_in_person", "preferred_hybrid"}).AddRow([]driver.Value{5, 5, 0, 10, 0, 0}...))
 
 	p := &ReportMatchesParams{
 		ChannelID:    channelID,

--- a/internal/bot/templates/report_matches.json.tmpl
+++ b/internal/bot/templates/report_matches.json.tmpl
@@ -82,6 +82,15 @@
 				"text": "*{{ .HasGenderPreference }}* {{ $sameGenderKeyword }} preferred to be matched with the same gender :blush:"
 			}
 		},
+{{- if .IsHybridConnectionMode }}
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*{{ .PreferredVirtual }}* preferred to meet virtually versus *{{ .PreferredInPerson }}* who preferred to meet in-person. Meanwhile, *{{ .PreferredHybrid }}* had no _Connection Mode_ preference"
+			}
+		},
+{{- end }}
 		{
 			"type": "section",
 			"text": {

--- a/internal/bot/testdata/report_matches_admin_connection_mode.json.golden
+++ b/internal/bot/testdata/report_matches_admin_connection_mode.json.golden
@@ -1,0 +1,78 @@
+{
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Hi <@U9876543210> :wave:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "A new round of Chat Roulette has just kicked off in <#C9876543210> :rocket:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "This round will run until *Monday, January 3rd, 2022*!"
+			}
+		},
+		{
+			"type": "header",
+			"text": {
+				"type": "plain_text",
+				"text": ":bar_chart: Match Stats",
+				"emoji": true
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "This round has *51* participants :tada:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*20* were :male_sign: and *30* were :female_sign:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*6* participants preferred to be matched with the same gender :blush:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*10* preferred to meet virtually versus *30* who preferred to meet in-person. Meanwhile, *11* had no _Connection Mode_ preference"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*1* participant did not get matched :cry:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*25* intros were made :raised_hands:"
+			}
+		}
+	]
+}


### PR DESCRIPTION
### :hammer_and_wrench:  Description

When sending the `REPORT_MATCHES` report to the admin at the start of a new round, include the Connection Mode preferences of the round's participants:

<img width="619" height="287" alt="Screenshot 2025-09-07 at 9 09 09 AM" src="https://github.com/user-attachments/assets/6245195b-e736-4455-b93e-d9d1464e4b79" />




### :+1:  Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] No linting issues?
