### PR TITLE
Fixed bug when rendering template for App Home for multiple Chat Roulette channels

### DIFF
--- a/internal/bot/event_app_home_test.go
+++ b/internal/bot/event_app_home_test.go
@@ -48,6 +48,33 @@ func Test_appHomeTemplate(t *testing.T) {
 			isErr:  false,
 		},
 		{
+			name:       "app user multiple channels",
+			goldenFile: "app_home_multiple_channels.json",
+			data: appHomeTemplate{
+				BotUserID: "U0123456789",
+				AppURL:    "https://chat-roulette-for-slack.com",
+				Channels: []models.Channel{
+					{
+						ChannelID:      "C0123456789",
+						Inviter:        "U0123456789",
+						Interval:       models.Biweekly,
+						ConnectionMode: models.ConnectionModeVirtual,
+						NextRound:      nextRound,
+					},
+					{
+						ChannelID:      "C9876543210",
+						Inviter:        "U0123456789",
+						Interval:       models.Monthly,
+						ConnectionMode: models.ConnectionModeHybrid,
+						NextRound:      nextRound,
+					},
+				},
+				IsAppUser: true,
+			},
+			blocks: 20,
+			isErr:  false,
+		},
+		{
 			name:       "non app user",
 			goldenFile: "app_home_non_user.json",
 			data: appHomeTemplate{

--- a/internal/bot/testdata/app_home_multiple_channels.json.golden
+++ b/internal/bot/testdata/app_home_multiple_channels.json.golden
@@ -3,7 +3,7 @@
 	"blocks": [
 		{
 			"type": "image",
-			"image_url": "{{ .AppURL }}/static/img/logo.png",
+			"image_url": "https://chat-roulette-for-slack.com/static/img/logo.png",
 			"alt_text": "chat-roulette logo"
 		},
 		{
@@ -39,7 +39,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "Chat Roulette can be enabled on a Slack channel by inviting <@{{ .BotUserID }}> to it!"
+				"text": "Chat Roulette can be enabled on a Slack channel by inviting <@U0123456789> to it!"
 			}
 		},
 		{
@@ -48,8 +48,7 @@
 				"type": "mrkdwn",
 				"text": "The Chat Roulette bot will then pair up members of the Slack channel every round giving participants ample time to connect. Based on the channel's _Connection Mode_ setting, the bot will suggest connecting in-person for :coffee: or virtually over :video_camera: using Zoom, Google Meet, or Microsoft Teams."
 			}
-		}
-{{- if .Channels }},
+		},
 		{
 			"type": "header",
 			"text": {
@@ -69,40 +68,57 @@
 					"text": "_Join any of the following channels to start connecting with members of your community_"
 				}
 			]
-		}
-{{- range .Channels }},
-	{{- $connectionMode := .ConnectionMode.String | capitalize }}
-	{{- if eq $connectionMode "Physical" }}
-		{{ $connectionMode = "In Person" }}
-	{{- end }}
+		},
 		{
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "<#{{ .ChannelID }}>"
+				"text": "<#C0123456789>"
 			},
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": ":hammer_and_wrench: Admin: <@{{ .Inviter }}>"
+					"text": ":hammer_and_wrench: Admin: <@U0123456789>"
 				},
 				{
 					"type": "mrkdwn",
-					"text": ":clock1: Interval: *{{ .Interval.String | capitalize }}*"
+					"text": ":clock1: Interval: *Biweekly*"
 				},
 				{
 					"type": "mrkdwn",
-					"text": ":busts_in_silhouette: Connection Mode: *{{ $connectionMode }}*"
+					"text": ":busts_in_silhouette: Connection Mode: *Virtual*"
 				},
 				{
 					"type": "mrkdwn",
-					"text": ":calendar: Next Round: *{{ .NextRound | prettyDate }}*"
+					"text": ":calendar: Next Round: *Monday, January 4th, 2021*"
 				}
 			]
-		}
-{{- end }}
-{{- end }}
-{{- if .IsAppUser }},
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "<#C9876543210>"
+			},
+			"fields": [
+				{
+					"type": "mrkdwn",
+					"text": ":hammer_and_wrench: Admin: <@U0123456789>"
+				},
+				{
+					"type": "mrkdwn",
+					"text": ":clock1: Interval: *Monthly*"
+				},
+				{
+					"type": "mrkdwn",
+					"text": ":busts_in_silhouette: Connection Mode: *Hybrid*"
+				},
+				{
+					"type": "mrkdwn",
+					"text": ":calendar: Next Round: *Monday, January 4th, 2021*"
+				}
+			]
+		},
 		{
 			"type": "header",
 			"text": {
@@ -172,10 +188,9 @@
 					"emoji": true
 				},
 				"value": "dashboard",
-				"url": "{{ .AppURL }}",
+				"url": "https://chat-roulette-for-slack.com",
 				"action_id": "link"
 			}
 		}
-{{- end }}
 	]
 }


### PR DESCRIPTION
### :hammer_and_wrench:  Description

> [ERROR] v1/events.go:216: failed to handle app_home_opened event: service.commit_sha=deb5d4ceb6 service.name=chat-roulette error="failed to unmarshal JSON: invalid character '{' after array element" 


### :+1:  Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] No linting issues?
